### PR TITLE
Don't quantize bn and biases

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ validate(...)
 Using this example you can quantize a pretrained model on imagenet.
 Compare the file to the [original example](https://github.com/pytorch/examples/tree/master/imagenet) to see the differences.
 
+#### Results	
+Results using this code differ slightly from the results reported in the paper. 	
+
+ |Network|Strategy|Bit-width|Top-1 Accuracy|Top-5 Accuracy|	
+|-------|--------|---------|--------------|--------------|	
+|resnet18|ref    |32       |69.758%       |89.078%       |	
+|resnet18|pruning|5        |69.64%        |89.07%        |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official Caffe implementation is available [[here]](https://github.com/AojunZhou
 
 ----
 ### Installation
-The code is implemented in Python 3.7 and PyTorch 1.0
+The code is implemented in Python 3.7 and PyTorch 1.1
 ```
 pip install -e .
 ```

--- a/examples/imagenet_quantized.py
+++ b/examples/imagenet_quantized.py
@@ -4,7 +4,6 @@ import random
 import shutil
 import time
 import warnings
-import sys
 
 import inq
 import torch
@@ -20,7 +19,6 @@ import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
 
-from tensorboardX import SummaryWriter
 
 model_names = sorted(name for name in models.__dict__
     if name.islower() and not name.startswith("__")
@@ -56,8 +54,6 @@ settings_dict = {
 
 best_acc1 = 0
 n_iter = 0
-
-writer = SummaryWriter(settings_dict['log_dir'])
 
 
 def main():
@@ -308,9 +304,6 @@ def train(train_loader, model, criterion, optimizer, epoch, args):
                   'Acc@5 {top5.val:.3f} ({top5.avg:.3f})'.format(
                    epoch, i, len(train_loader), batch_time=batch_time,
                    data_time=data_time, loss=losses, top1=top1, top5=top5))
-            writer.add_scalar('Train/Loss', losses.val, n_iter)
-            writer.add_scalar('Train/Prec@1', top1.val, n_iter)
-            writer.add_scalar('Train/Prec@5', top5.val, n_iter)
             n_iter += args.print_freq
 
 
@@ -357,9 +350,6 @@ def validate(val_loader, model, criterion, args):
         print(' * Acc@1 {top1.avg:.3f} Acc@5 {top5.avg:.3f}'
               .format(top1=top1, top5=top5))
 
-    writer.add_scalar('Test/Loss', losses.avg, n_iter)
-    writer.add_scalar('Test/Prec@1', top1.avg, n_iter)
-    writer.add_scalar('Test/Prec@5', top5.avg, n_iter)
     return top1.avg
 
 

--- a/inq/quantization_scheduler.py
+++ b/inq/quantization_scheduler.py
@@ -41,6 +41,8 @@ class INQScheduler(object):
 
         for group in self.optimizer.param_groups:
             group['ns'] = []
+            if group['weight_bits'] is None:
+                continue
             for p in group['params']:
                 if p.requires_grad is False:
                     group['ns'].append((0, 0))
@@ -72,6 +74,8 @@ class INQScheduler(object):
             for idx, p in enumerate(group['params']):
                 if p.requires_grad is False:
                     continue
+                if group['weight_bits'] is None:
+                    continue
                 T = group['Ts'][idx]
                 ns = group['ns'][idx]
                 device = p.data.device
@@ -100,6 +104,8 @@ class INQScheduler(object):
         for group in self.optimizer.param_groups:
             for idx, p in enumerate(group['params']):
                 if p.requires_grad is False:
+                    continue
+                if group['weight_bits'] is None:
                     continue
                 if self.strategy == "random":
                     if self.idx == 0:
@@ -143,7 +149,7 @@ def reset_lr_scheduler(scheduler):
         >>> validate(...)
     """
     scheduler.base_lrs = list(map(lambda group: group['initial_lr'], scheduler.optimizer.param_groups))
-    last_epoch = -1
-    scheduler.step(last_epoch + 1)
+    last_epoch = 0
     scheduler.last_epoch = last_epoch
+    scheduler.step(last_epoch)
 


### PR DESCRIPTION
Reproduce paper results by not quantizing batchnorm parameters and biases.
Also updated to Pytorch 1.1

- [ ] Update README with achieved accuracy

