### PR TITLE
Enable Passing Options through Command Line + Save Train Log

### DIFF
--- a/examples/imagenet_quantized.py
+++ b/examples/imagenet_quantized.py
@@ -96,6 +96,8 @@ def main_worker(gpu, ngpus_per_node, args):
     global best_acc1
     args.gpu = gpu
 
+    if args.log_dir is None:
+        args.log_dir = os.path.join('.', 'models', args.arch + '_inq_pruning')
     os.makedirs(args.log_dir, exist_ok=True)
 
     if args.gpu is not None:

--- a/examples/imagenet_quantized.py
+++ b/examples/imagenet_quantized.py
@@ -310,7 +310,7 @@ def main_worker(gpu, ngpus_per_node, args):
             save_checkpoint({
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
-            }, is_best, filename=os.path.join(args.log_dir, 'quantized_{}_pruning.pth.tar'.format(args.arch)))
+            }, False, filename=os.path.join(args.log_dir, 'quantized_{}_pruning.pth.tar'.format(args.arch)))
 
 
 def train(train_loader, model, criterion, optimizer, epoch, args):


### PR DESCRIPTION
- Enable passing the settings through command line options
- Use architecture name in default for log_dir to save the checkpoint to
- Create train_logs.csv file to log training log